### PR TITLE
Add DayByDay navbar in dashboard

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,7 @@
   <body>
 
   <!-- Navbar -->
+  {% block navbar %}
   <nav class="navbar navbar-expand-lg">
       <div class="container">
         <a class="navbar-brand" href="/">Habit Tracker</a>
@@ -31,6 +32,7 @@
         </div>
       </div>
     </nav>
+  {% endblock %}
 
     <div class="container py-4">
       <!-- Flash messages -->

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,6 +2,16 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
 {% endblock %}
+{% block navbar %}
+  <nav class="navbar navbar-expand-lg">
+      <div class="container">
+        <span class="navbar-brand">DayByDay</span>
+        <div>
+          <a href="{{ url_for('logout') }}" class="btn btn-outline-secondary">Logout</a>
+        </div>
+      </div>
+  </nav>
+{% endblock %}
 {% block content %}
 <div class="d-flex flex-column align-items-center justify-content-center dashboard-gap">
     <a href="{{ url_for('habit_tracker') }}" class="btn btn-primary btn-lg mb-3">Habit Tracker</a>


### PR DESCRIPTION
## Summary
- allow overriding the navbar section in templates
- customize dashboard page navbar to show "DayByDay" and a Logout button

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684fe9d006608328a2169ee5b65b657f