### PR TITLE
Adjust navbar and monthly planner actions

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -29,7 +29,13 @@
         <a class="navbar-brand fw-bold" href="/">DayByDay</a>
         <div class="d-flex align-items-center">
           {% if session.get('user_id') %}
-            <a href="/habits" class="btn btn-outline-primary me-2">Manage Habits</a>
+            <a href="{{ url_for('dashboard') }}" class="btn btn-outline-secondary me-2"><i class="bi bi-house"></i> Home</a>
+            {% if request.endpoint != 'planner_view' %}
+              <a href="/habits" class="btn btn-outline-primary me-2">Manage Habits</a>
+            {% endif %}
+            {% if request.endpoint == 'planner_view' %}
+              <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#addTaskModal">Add Task</button>
+            {% endif %}
             <a href="/logout" class="btn btn-outline-secondary">Logout</a>
           {% else %}
             <a href="/login" class="btn btn-outline-primary me-2">Login</a>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,7 +6,8 @@
   <nav class="navbar navbar-expand-lg">
       <div class="container">
          <a class="navbar-brand" href="{{ url_for('dashboard') }}">DayByDay</a>
-        <div class="ms-auto">
+        <div class="ms-auto d-flex align-items-center">
+          <a href="{{ url_for('dashboard') }}" class="btn btn-outline-secondary me-2"><i class="bi bi-house"></i> Home</a>
           <a href="{{ url_for('logout') }}" class="btn btn-outline-secondary">Logout</a>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,6 @@
   <h2 class="mb-0">{{ month_name }} {{ year }}</h2>
   <div>
     <a class="btn btn-outline-primary" href="{{ url_for('calendar_view', year=next_year, month=next_month) }}">Next</a>
-    <a class="btn btn-outline-secondary ms-2" href="{{ url_for('dashboard') }}"><i class="bi bi-house"></i> Home</a>
   </div>
 </div>
 

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -5,8 +5,6 @@
   <h2 class="mb-0">{{ month_name }} {{ year }}</h2>
   <div>
     <a class="btn btn-outline-primary" href="{{ url_for('planner_view', year=next_year, month=next_month) }}">Next</a>
-    <a class="btn btn-outline-secondary ms-2" href="{{ url_for('dashboard') }}"><i class="bi bi-house"></i> Home</a>
-    <button class="btn btn-primary ms-2" data-bs-toggle="modal" data-bs-target="#addTaskModal">Add Task</button>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- show a Home button in the navbar everywhere
- hide `Manage Habits` button on the monthly planner view
- move `Add Task` button into the navbar only on the planner view
- remove old Home/Add Task buttons from planner and calendar headers

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68502cca5d848328ae3bb3b7752eeb16