### PR TITLE
Fix calendar box text overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -62,12 +62,18 @@ body {
   border-radius: 8px;
   padding: 12px;
   min-height: 100px;
+  max-height: 100px;
   font-size: 0.8rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   text-align: right;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
+  overflow-y: auto;
+  box-sizing: border-box;
   cursor: pointer;
   transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- ensure text wraps inside calendar day boxes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504979aa508328aa1da8ee719e23f1